### PR TITLE
Add attraction detail pages with green theme

### DIFF
--- a/app/attractions/[id]/page.js
+++ b/app/attractions/[id]/page.js
@@ -1,0 +1,35 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+
+export default async function AttractionPage({ params }) {
+  const { id } = params;
+  const res = await fetch(`https://www.melivecode.com/api/attractions/${id}`);
+
+  if (!res.ok) {
+    notFound();
+  }
+
+  const data = await res.json();
+
+  if (data.status !== "ok") {
+    notFound();
+  }
+
+  const { attraction } = data;
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 sm:p-8">
+      <h1 className="text-3xl font-semibold mb-6 text-center">
+        {attraction.name}
+      </h1>
+      <Image
+        src={attraction.coverimage}
+        alt={attraction.name}
+        width={600}
+        height={400}
+        className="w-full h-72 object-cover rounded-lg shadow mb-6"
+      />
+      <p className="text-lg leading-relaxed">{attraction.detail}</p>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f0fdf4;
+  --foreground: #064e3b;
 }
 
 @theme inline {
@@ -14,8 +14,8 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #052e16;
+    --foreground: #dcfce7;
   }
 }
 

--- a/app/page.js
+++ b/app/page.js
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default async function Home() {
   const res = await fetch("https://www.melivecode.com/api/attractions", {
@@ -13,21 +14,23 @@ export default async function Home() {
         {attractions.map((attraction) => (
           <div
             key={attraction.id}
-            className="bg-white dark:bg-gray-900 rounded-lg overflow-hidden shadow"
+            className="bg-green-100 dark:bg-green-900 rounded-lg overflow-hidden shadow"
           >
-            <Image
-              src={attraction.coverimage}
-              alt={attraction.name}
-              width={400}
-              height={250}
-              className="w-full h-48 object-cover"
-            />
-            <div className="p-4">
-              <h2 className="font-medium text-lg mb-1">{attraction.name}</h2>
-              <p className="text-sm text-gray-700 dark:text-gray-300 line-clamp-3">
-                {attraction.detail}
-              </p>
-            </div>
+            <Link href={`/attractions/${attraction.id}`} className="block hover:opacity-90">
+              <Image
+                src={attraction.coverimage}
+                alt={attraction.name}
+                width={400}
+                height={250}
+                className="w-full h-48 object-cover"
+              />
+              <div className="p-4">
+                <h2 className="font-medium text-lg mb-1">{attraction.name}</h2>
+                <p className="text-sm text-green-800 dark:text-green-200 line-clamp-3">
+                  {attraction.detail}
+                </p>
+              </div>
+            </Link>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add dynamic attraction detail route
- link to the new route from the home grid
- apply green color scheme in global styles

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684407f1bc48832f84ef06d206d8e82f